### PR TITLE
Fix CVE vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,24 +46,23 @@
          <version>2.2.3</version>
       </dependency>
 
- <dependency>
-         <groupId>org.apache.poi</groupId>
-         <artifactId>poi</artifactId>
-         <version>5.2.4</version>
-      </dependency>
+<dependency>
+    <groupId>org.apache.poi</groupId>
+    <artifactId>poi</artifactId>
+    <version>5.2.4</version>
+</dependency>
 
-      <dependency>
-         <groupId>org.apache.poi</groupId>
-         <artifactId>poi-ooxml</artifactId>
-         <version>5.2.4</version>
-      </dependency>
+<dependency>
+    <groupId>org.apache.poi</groupId>
+    <artifactId>poi-ooxml</artifactId>
+    <version>5.2.4</version>
+</dependency>
 
 <dependency>
     <groupId>org.apache.poi</groupId>
     <artifactId>poi-ooxml-lite</artifactId>
-         <version>5.2.4</version>
+    <version>5.2.4</version>
 </dependency>
-
 
 <dependency>
     <groupId>org.apache.logging.log4j</groupId>
@@ -80,13 +79,13 @@
 <dependency>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-compress</artifactId>
-    <version>1.24.0</version>
+    <version>1.26.2</version>
 </dependency>
 
 <dependency>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-collections4</artifactId>
-    <version>4.4</version>
+    <version>4.5.0-M1</version>
 </dependency>
 
    </dependencies>
@@ -96,7 +95,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.1</version>
+            <version>3.9.0</version>
             <configuration>
                <source>11</source>
                <target>11</target>
@@ -105,7 +104,7 @@
          <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
-            <version>5.1.8</version>
+            <version>5.1.9</version>
             <extensions>true</extensions>
             <configuration>
                <instructions>
@@ -194,7 +193,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-source-plugin</artifactId>
-                  <version>2.2.1</version>
+                  <version>3.3.1</version>
                   <executions>
                      <execution>
                         <id>attach-sources</id>
@@ -208,7 +207,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-javadoc-plugin</artifactId>
-                  <version>2.10.3</version>
+                  <version>3.6.3</version>
                   <executions>
                      <execution>
                         <id>attach-javadocs</id>
@@ -226,7 +225,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-gpg-plugin</artifactId>
-                  <version>1.6</version>
+                  <version>3.2.4</version>
                   <executions>
                      <execution>
                         <id>sign-artifacts</id>


### PR DESCRIPTION
fix CVE vulnerabilities

commons-compress
[CVE-2024-26308](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26308)
[CVE-2024-25710](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-25710)
[Apache Commons Collections]
[CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)
maven-compiler-plugin
[CVE-2022-29599](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29599)
[CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)
maven-source-plugin
[CVE-2023-37460](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37460)
[CVE-2022-4245](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4245)
[CVE-2022-4244](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4244)
[CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)
[CVE-2018-1002200](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1002200)
[CVE-2017-1000487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1000487)
maven-javadoc-plugin
[CVE-2023-37460](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37460)
[CVE-2022-4245](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4245)
[CVE-2022-4244](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4244)
[CVE-2022-23307](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23307)
[CVE-2022-23305](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23305)
[CVE-2022-23302](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23302)
[CVE-2021-4104](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4104)
[CVE-2021-29425](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29425)
[CVE-2020-13956](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13956)
[CVE-2019-17571](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17571)
[CVE-2018-1002200](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1002200)
[CVE-2015-5262](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5262)
[CVE-2014-3577](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3577)
[CVE-2009-4611](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-4611)
maven-gpg-plugin
[CVE-2022-4245](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4245)
[CVE-2022-4244](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4244)